### PR TITLE
Implement dialog manager and hello dialog

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -146,16 +146,16 @@ a small debug label in the bottom-right corner.
 
 #### `src/PauseMenu.tsx`
 
-Pause menu dialog built on top of the generic `Dialog` component. Renders a
-list of options via `MenuOption`. Keyboard navigation only works when the menu
-is the top dialog in the stack. Provides a "Show Dialog" option for manual
-tests and accepts an `onExit` callback used to close the dialog and resume the
-game.
+Pause menu dialog built on top of the generic `Dialog` component. Options are
+standard buttons navigated via the browser's focus order. The first option is
+focused automatically when the menu is the top dialog. Provides a "Show Dialog"
+option for manual tests and accepts an `onExit` callback used to close the
+dialog and resume the game.
 
 #### `src/MenuOption.tsx`
 
-Reusable button component for menu entries. Exports `MenuOptionProps` and the
-default `MenuOption` React component.
+Reusable button component for menu entries. Accepts an `isTop` flag to enable
+focus with the Tab key only for the top dialog.
 
 #### `src/App.tsx`
 
@@ -167,9 +167,10 @@ the pause state is updated via the dialog's `onClose` callback.
 #### `src/ui/DialogManager.tsx`
 
 Context provider that maintains a stack of modal dialogs. `showDialog` accepts a
-render function and returns a unique dialog id. The provider tracks the id of
-the top dialog and exposes `closeDialog`, `useDialogManager`, and
-`useIsTopDialog` helpers with global `Escape` key support.
+render function and returns a unique dialog id. Only the top dialog is visible
+and tabbable. The provider tracks the id of the top dialog and exposes
+`closeDialog`, `useDialogManager`, and `useIsTopDialog` helpers with global
+`Escape` key support.
 
 #### `src/ui/Dialog.tsx`
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -146,10 +146,11 @@ a small debug label in the bottom-right corner.
 
 #### `src/PauseMenu.tsx`
 
-Pause menu overlay with "Menu" and "The Drift" titles. Renders a list of
-options via `MenuOption`. Supports keyboard navigation with arrow keys and
-selection with Enter or the mouse. Accepts an `onExit` callback to resume the
-game. Includes a "Show Dialog" option for manual dialog tests.
+Pause menu dialog built on top of the generic `Dialog` component. Renders a
+list of options via `MenuOption`. Keyboard navigation only works when the menu
+is the top dialog in the stack. Provides a "Show Dialog" option for manual
+tests and accepts an `onExit` callback used to close the dialog and resume the
+game.
 
 #### `src/MenuOption.tsx`
 
@@ -158,16 +159,17 @@ default `MenuOption` React component.
 
 #### `src/App.tsx`
 
-Root React component. Renders `LayeredLayout` which hosts the game and UI
-layers. Wrapped in `DialogProvider` to manage modal dialogs. Handles `Escape`
-key to toggle the `PauseMenu` layer when no dialogs are open and passes the
-pause state to `GameCanvas`.
+Root React component. Renders `LayeredLayout` with the `GameCanvas` and wraps
+everything in `DialogProvider`. Pressing `Escape` opens the `PauseMenu` dialog
+when no dialogs are active. The provider closes the top dialog on `Escape` and
+the pause state is updated via the dialog's `onClose` callback.
 
 #### `src/ui/DialogManager.tsx`
 
-Context provider that maintains a stack of modal dialogs. Exports
-`DialogProvider` and `useDialogManager` for opening and closing dialogs with
-global `Escape` key support.
+Context provider that maintains a stack of modal dialogs. `showDialog` accepts a
+render function and returns a unique dialog id. The provider tracks the id of
+the top dialog and exposes `closeDialog`, `useDialogManager`, and
+`useIsTopDialog` helpers with global `Escape` key support.
 
 #### `src/ui/Dialog.tsx`
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -149,7 +149,7 @@ a small debug label in the bottom-right corner.
 Pause menu overlay with "Menu" and "The Drift" titles. Renders a list of
 options via `MenuOption`. Supports keyboard navigation with arrow keys and
 selection with Enter or the mouse. Accepts an `onExit` callback to resume the
-game.
+game. Includes a "Show Dialog" option for manual dialog tests.
 
 #### `src/MenuOption.tsx`
 
@@ -159,8 +159,19 @@ default `MenuOption` React component.
 #### `src/App.tsx`
 
 Root React component. Renders `LayeredLayout` which hosts the game and UI
-layers. Handles `Escape` key to toggle the `PauseMenu` layer and passes the
+layers. Wrapped in `DialogProvider` to manage modal dialogs. Handles `Escape`
+key to toggle the `PauseMenu` layer when no dialogs are open and passes the
 pause state to `GameCanvas`.
+
+#### `src/ui/DialogManager.tsx`
+
+Context provider that maintains a stack of modal dialogs. Exports
+`DialogProvider` and `useDialogManager` for opening and closing dialogs with
+global `Escape` key support.
+
+#### `src/ui/Dialog.tsx`
+
+Reusable dialog container component with a title, content area and close button.
 
 ---
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -175,6 +175,7 @@ and tabbable. The provider tracks the id of the top dialog and exposes
 #### `src/ui/Dialog.tsx`
 
 Reusable dialog container component with a title, content area and close button.
+Uses `focus-trap-react` to keep focus inside the dialog when it is on top.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "homepage": "https://github.com/harnyk/the-drift",
   "dependencies": {
     "clsx": "^2.1.1",
+    "focus-trap-react": "^11.0.4",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "vercel": "^42.3.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
+      focus-trap-react:
+        specifier: ^11.0.4
+        version: 11.0.4(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react:
         specifier: ^18.2.0
         version: 18.3.1
@@ -1243,6 +1246,17 @@ packages:
     resolution: {integrity: sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==}
     engines: {node: '>=8'}
 
+  focus-trap-react@11.0.4:
+    resolution: {integrity: sha512-tC7jC/yqeAqhe4irNIzdyDf9XCtGSeECHiBSYJBO/vIN0asizbKZCt8TarB6/XqIceu42ajQ/U4lQJ9pZlWjrg==}
+    peerDependencies:
+      '@types/react': ^18.0.0 || ^19.0.0
+      '@types/react-dom': ^18.0.0 || ^19.0.0
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+
+  focus-trap@7.6.5:
+    resolution: {integrity: sha512-7Ke1jyybbbPZyZXFxEftUtxFGLMpE2n6A+z//m4CRDlj0hW+o3iYSmh8nFlYMurOiJVDmJRilUQtJr08KfIxlg==}
+
   foreground-child@3.3.1:
     resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
     engines: {node: '>=14'}
@@ -2156,6 +2170,9 @@ packages:
   supports-preserve-symlinks-flag@1.0.0:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
+
+  tabbable@6.2.0:
+    resolution: {integrity: sha512-Cat63mxsVJlzYvN51JmVXIgNoUokrIaT2zLclCXjRd8boZ0004U4KCs/sToJ75C6sdlByWxpYnb5Boif1VSFew==}
 
   tailwindcss@3.4.17:
     resolution: {integrity: sha512-w33E2aCvSDP0tW9RZuNXadXlkHXqFzSkQew/aIa2i/Sj8fThxwovwlXHSPXTbAHwEIhBFXAedUhP2tueAKP8Og==}
@@ -3728,6 +3745,19 @@ snapshots:
       locate-path: 5.0.0
       path-exists: 4.0.0
 
+  focus-trap-react@11.0.4(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      '@types/react': 18.3.23
+      '@types/react-dom': 18.3.7(@types/react@18.3.23)
+      focus-trap: 7.6.5
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      tabbable: 6.2.0
+
+  focus-trap@7.6.5:
+    dependencies:
+      tabbable: 6.2.0
+
   foreground-child@3.3.1:
     dependencies:
       cross-spawn: 7.0.6
@@ -4715,6 +4745,8 @@ snapshots:
       has-flag: 4.0.0
 
   supports-preserve-symlinks-flag@1.0.0: {}
+
+  tabbable@6.2.0: {}
 
   tailwindcss@3.4.17(ts-node@10.9.1(@types/node@16.18.11)(typescript@5.8.3)):
     dependencies:

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -6,28 +6,33 @@ import { DialogProvider, useDialogManager } from './DialogManager';
 
 const InnerApp: React.FC = () => {
     const [paused, setPaused] = useState(false);
-    const { hasDialog } = useDialogManager();
+    const { hasDialog, showDialog, closeDialog } = useDialogManager();
 
     useEffect(() => {
         const onKeyDown = (e: KeyboardEvent) => {
             if (e.code === 'Escape' && !hasDialog) {
-                setPaused((p) => !p);
+                setPaused(true);
+                showDialog(
+                    (id, isTop) => (
+                        <PauseMenu
+                            dialogId={id}
+                            isTop={isTop}
+                            onExit={() => closeDialog(id)}
+                        />
+                    ),
+                    () => setPaused(false)
+                );
             }
         };
         window.addEventListener('keydown', onKeyDown);
         return () => {
             window.removeEventListener('keydown', onKeyDown);
         };
-    }, [hasDialog]);
+    }, [hasDialog, showDialog, closeDialog]);
 
-    const layers: React.ReactNode[] = [
-        <GameCanvas key="game" paused={paused} />,
-    ];
-    if (paused) {
-        layers.push(<PauseMenu key="pause" onExit={() => setPaused(false)} />);
-    }
-
-    return <LayeredLayout layers={layers} />;
+    return (
+        <LayeredLayout layers={[<GameCanvas key="game" paused={paused} />]} />
+    );
 };
 
 const App: React.FC = () => (

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -2,13 +2,15 @@ import React, { useEffect, useState } from 'react';
 import LayeredLayout from './LayeredLayout';
 import GameCanvas from './GameCanvas';
 import PauseMenu from './PauseMenu';
+import { DialogProvider, useDialogManager } from './DialogManager';
 
-const App: React.FC = () => {
+const InnerApp: React.FC = () => {
     const [paused, setPaused] = useState(false);
+    const { hasDialog } = useDialogManager();
 
     useEffect(() => {
         const onKeyDown = (e: KeyboardEvent) => {
-            if (e.code === 'Escape') {
+            if (e.code === 'Escape' && !hasDialog) {
                 setPaused((p) => !p);
             }
         };
@@ -16,7 +18,7 @@ const App: React.FC = () => {
         return () => {
             window.removeEventListener('keydown', onKeyDown);
         };
-    }, []);
+    }, [hasDialog]);
 
     const layers: React.ReactNode[] = [
         <GameCanvas key="game" paused={paused} />,
@@ -27,5 +29,11 @@ const App: React.FC = () => {
 
     return <LayeredLayout layers={layers} />;
 };
+
+const App: React.FC = () => (
+    <DialogProvider>
+        <InnerApp />
+    </DialogProvider>
+);
 
 export default App;

--- a/src/ui/Dialog.tsx
+++ b/src/ui/Dialog.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+
+export interface DialogProps {
+    title: string;
+    children: React.ReactNode;
+    onClose: () => void;
+}
+
+const Dialog: React.FC<DialogProps> = ({ title, children, onClose }) => {
+    return (
+        <div className="bg-gray-800 bg-opacity-90 rounded p-4 w-64 text-center">
+            <h2 className="text-red-600 font-mono text-xl mb-2">{title}</h2>
+            <div className="text-white mb-4">{children}</div>
+            <button
+                className="px-4 py-2 font-mono border border-red-600 rounded hover:bg-red-600 hover:text-black"
+                onClick={onClose}
+            >
+                Close
+            </button>
+        </div>
+    );
+};
+
+export default Dialog;

--- a/src/ui/Dialog.tsx
+++ b/src/ui/Dialog.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import FocusTrap from 'focus-trap-react';
 
 export interface DialogProps {
     title: string;
@@ -9,17 +10,22 @@ export interface DialogProps {
 
 const Dialog: React.FC<DialogProps> = ({ title, children, onClose, isTop }) => {
     return (
-        <div className="bg-gray-800 bg-opacity-90 rounded p-4 w-64 text-center">
-            <h2 className="text-red-600 font-mono text-xl mb-2">{title}</h2>
-            <div className="text-white mb-4">{children}</div>
-            <button
-                className="px-4 py-2 font-mono border border-red-600 rounded hover:bg-red-600 hover:text-black"
-                tabIndex={isTop ? 0 : -1}
-                onClick={onClose}
-            >
-                Close
-            </button>
-        </div>
+        <FocusTrap
+            active={isTop}
+            focusTrapOptions={{ allowOutsideClick: false, initialFocus: false }}
+        >
+            <div className="bg-gray-800 bg-opacity-90 rounded p-4 w-64 text-center">
+                <h2 className="text-red-600 font-mono text-xl mb-2">{title}</h2>
+                <div className="text-white mb-4">{children}</div>
+                <button
+                    className="px-4 py-2 font-mono border border-red-600 rounded hover:bg-red-600 hover:text-black"
+                    tabIndex={isTop ? 0 : -1}
+                    onClick={onClose}
+                >
+                    Close
+                </button>
+            </div>
+        </FocusTrap>
     );
 };
 

--- a/src/ui/Dialog.tsx
+++ b/src/ui/Dialog.tsx
@@ -4,15 +4,17 @@ export interface DialogProps {
     title: string;
     children: React.ReactNode;
     onClose: () => void;
+    isTop: boolean;
 }
 
-const Dialog: React.FC<DialogProps> = ({ title, children, onClose }) => {
+const Dialog: React.FC<DialogProps> = ({ title, children, onClose, isTop }) => {
     return (
         <div className="bg-gray-800 bg-opacity-90 rounded p-4 w-64 text-center">
             <h2 className="text-red-600 font-mono text-xl mb-2">{title}</h2>
             <div className="text-white mb-4">{children}</div>
             <button
                 className="px-4 py-2 font-mono border border-red-600 rounded hover:bg-red-600 hover:text-black"
+                tabIndex={isTop ? 0 : -1}
                 onClick={onClose}
             >
                 Close

--- a/src/ui/DialogManager.tsx
+++ b/src/ui/DialogManager.tsx
@@ -1,0 +1,51 @@
+import React, { createContext, useCallback, useContext, useEffect, useState } from 'react';
+
+export interface DialogManagerContext {
+    showDialog: (dialog: React.ReactNode) => void;
+    closeDialog: () => void;
+    hasDialog: boolean;
+}
+
+const Context = createContext<DialogManagerContext | null>(null);
+
+export const DialogProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+    const [stack, setStack] = useState<React.ReactNode[]>([]);
+
+    const showDialog = useCallback((dialog: React.ReactNode) => {
+        setStack((s) => [...s, dialog]);
+    }, []);
+
+    const closeDialog = useCallback(() => {
+        setStack((s) => s.slice(0, -1));
+    }, []);
+
+    useEffect(() => {
+        const onKeyDown = (e: KeyboardEvent) => {
+            if (e.code === 'Escape' && stack.length > 0) {
+                e.preventDefault();
+                closeDialog();
+            }
+        };
+        window.addEventListener('keydown', onKeyDown);
+        return () => window.removeEventListener('keydown', onKeyDown);
+    }, [stack.length, closeDialog]);
+
+    return (
+        <Context.Provider value={{ showDialog, closeDialog, hasDialog: stack.length > 0 }}>
+            {children}
+            {stack.map((dialog, idx) => (
+                <div key={idx} className="absolute inset-0 flex items-center justify-center bg-black bg-opacity-50" style={{ zIndex: 100 + idx }}>
+                    {dialog}
+                </div>
+            ))}
+        </Context.Provider>
+    );
+};
+
+export const useDialogManager = (): DialogManagerContext => {
+    const ctx = useContext(Context);
+    if (!ctx) {
+        throw new Error('useDialogManager must be used within DialogProvider');
+    }
+    return ctx;
+};

--- a/src/ui/DialogManager.tsx
+++ b/src/ui/DialogManager.tsx
@@ -69,15 +69,21 @@ export const DialogProvider: React.FC<{ children: React.ReactNode }> = ({ childr
     return (
         <Context.Provider value={{ showDialog, closeDialog, hasDialog: stack.length > 0, topId }}>
             {children}
-            {stack.map((entry, idx) => (
-                <div
-                    key={entry.id}
-                    className="absolute inset-0 flex items-center justify-center bg-black bg-opacity-50"
-                    style={{ zIndex: 100 + idx }}
-                >
-                    {entry.render(entry.id, idx === stack.length - 1)}
-                </div>
-            ))}
+            {stack.map((entry, idx) => {
+                const isTop = idx === stack.length - 1;
+                return (
+                    <div
+                        key={entry.id}
+                        className={
+                            'absolute inset-0 flex items-center justify-center bg-black bg-opacity-50' +
+                            (isTop ? '' : ' hidden')
+                        }
+                        style={{ zIndex: 100 + idx }}
+                    >
+                        {entry.render(entry.id, isTop)}
+                    </div>
+                );
+            })}
         </Context.Provider>
     );
 };

--- a/src/ui/DialogManager.tsx
+++ b/src/ui/DialogManager.tsx
@@ -1,23 +1,57 @@
-import React, { createContext, useCallback, useContext, useEffect, useState } from 'react';
+import React, {
+    createContext,
+    useCallback,
+    useContext,
+    useEffect,
+    useRef,
+    useState,
+} from 'react';
 
 export interface DialogManagerContext {
-    showDialog: (dialog: React.ReactNode) => void;
-    closeDialog: () => void;
+    showDialog: (
+        render: (id: number, isTop: boolean) => React.ReactNode,
+        onClose?: () => void
+    ) => number;
+    closeDialog: (id?: number) => void;
     hasDialog: boolean;
+    topId: number | null;
+}
+
+interface DialogEntry {
+    id: number;
+    render: (id: number, isTop: boolean) => React.ReactNode;
+    onClose?: () => void;
 }
 
 const Context = createContext<DialogManagerContext | null>(null);
 
 export const DialogProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
-    const [stack, setStack] = useState<React.ReactNode[]>([]);
+    const [stack, setStack] = useState<DialogEntry[]>([]);
+    const nextId = useRef(1);
 
-    const showDialog = useCallback((dialog: React.ReactNode) => {
-        setStack((s) => [...s, dialog]);
-    }, []);
+    const showDialog = useCallback(
+        (render: (id: number, isTop: boolean) => React.ReactNode, onClose?: () => void): number => {
+            const id = nextId.current++;
+            setStack((s) => [...s, { id, render, onClose }]);
+            return id;
+        },
+        []
+    );
 
-    const closeDialog = useCallback(() => {
-        setStack((s) => s.slice(0, -1));
-    }, []);
+    const closeDialog = useCallback(
+        (id?: number) => {
+            setStack((s) => {
+                if (s.length === 0) return s;
+                const top = s[s.length - 1];
+                if (id === undefined || top.id === id) {
+                    top.onClose?.();
+                    return s.slice(0, -1);
+                }
+                return s;
+            });
+        },
+        []
+    );
 
     useEffect(() => {
         const onKeyDown = (e: KeyboardEvent) => {
@@ -30,12 +64,18 @@ export const DialogProvider: React.FC<{ children: React.ReactNode }> = ({ childr
         return () => window.removeEventListener('keydown', onKeyDown);
     }, [stack.length, closeDialog]);
 
+    const topId = stack.length ? stack[stack.length - 1].id : null;
+
     return (
-        <Context.Provider value={{ showDialog, closeDialog, hasDialog: stack.length > 0 }}>
+        <Context.Provider value={{ showDialog, closeDialog, hasDialog: stack.length > 0, topId }}>
             {children}
-            {stack.map((dialog, idx) => (
-                <div key={idx} className="absolute inset-0 flex items-center justify-center bg-black bg-opacity-50" style={{ zIndex: 100 + idx }}>
-                    {dialog}
+            {stack.map((entry, idx) => (
+                <div
+                    key={entry.id}
+                    className="absolute inset-0 flex items-center justify-center bg-black bg-opacity-50"
+                    style={{ zIndex: 100 + idx }}
+                >
+                    {entry.render(entry.id, idx === stack.length - 1)}
                 </div>
             ))}
         </Context.Provider>
@@ -48,4 +88,9 @@ export const useDialogManager = (): DialogManagerContext => {
         throw new Error('useDialogManager must be used within DialogProvider');
     }
     return ctx;
+};
+
+export const useIsTopDialog = (id: number): boolean => {
+    const { topId } = useDialogManager();
+    return topId === id;
 };

--- a/src/ui/MenuOption.tsx
+++ b/src/ui/MenuOption.tsx
@@ -4,27 +4,25 @@ import clsx from 'clsx';
 export interface MenuOptionProps {
     label: string;
     onSelect: () => void;
-    selected: boolean;
     buttonRef: (el: HTMLButtonElement | null) => void;
+    isTop: boolean;
 }
 
 const MenuOption: React.FC<MenuOptionProps> = ({
     label,
     onSelect,
-    selected,
     buttonRef,
+    isTop,
 }) => {
     const className = clsx(
         'w-full',
         'px-4 py-2 font-mono border border-red-600 rounded mb-2 focus:outline-none',
         'hover:bg-red-600 hover:text-black',
-        {
-            'bg-red-600 text-black': selected,
-            'text-red-600': !selected,
-        }
+        'focus:bg-red-600 focus:text-black',
+        'text-red-600',
     );
     return (
-        <button ref={buttonRef} onClick={onSelect} className={className}>
+        <button ref={buttonRef} onClick={onSelect} className={className} tabIndex={isTop ? 0 : -1}>
             {label}
         </button>
     );

--- a/src/ui/PauseMenu.tsx
+++ b/src/ui/PauseMenu.tsx
@@ -1,15 +1,25 @@
 import React, { useEffect, useRef, useState } from 'react';
 import MenuOption from './MenuOption';
+import Dialog from './Dialog';
+import { useDialogManager } from './DialogManager';
 
 export interface PauseMenuProps {
     onExit: () => void;
 }
 
 const PauseMenu: React.FC<PauseMenuProps> = ({ onExit }) => {
+    const { showDialog, closeDialog } = useDialogManager();
     const options = [
-        // { label: 'Option 1', onSelect: () => console.log('Option 1 selected') },
-        // { label: 'Option 2', onSelect: () => console.log('Option 2 selected') },
-        // { label: 'Option 3', onSelect: () => console.log('Option 3 selected') },
+        {
+            label: 'Show Dialog',
+            onSelect: () => {
+                showDialog(
+                    <Dialog title="Hello" onClose={closeDialog}>
+                        hello world
+                    </Dialog>
+                );
+            },
+        },
         { label: 'Exit', onSelect: () => { console.log('Exit selected'); onExit(); } },
     ];
     const [selected, setSelected] = useState(0);

--- a/src/ui/PauseMenu.tsx
+++ b/src/ui/PauseMenu.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useRef } from 'react';
 import MenuOption from './MenuOption';
 import Dialog from './Dialog';
 import { useDialogManager } from './DialogManager';
@@ -15,54 +15,42 @@ const PauseMenu: React.FC<PauseMenuProps> = ({ onExit, dialogId, isTop }) => {
         {
             label: 'Show Dialog',
             onSelect: () => {
-                showDialog((id) => (
-                    <Dialog title="Hello" onClose={() => closeDialog(id)}>
+                showDialog((id, top) => (
+                    <Dialog title="Hello" onClose={() => closeDialog(id)} isTop={top}>
                         hello world
                     </Dialog>
                 ));
             },
         },
-        { label: 'Exit', onSelect: () => { console.log('Exit selected'); onExit(); } },
+        {
+            label: 'Exit',
+            onSelect: () => {
+                console.log('Exit selected');
+                onExit();
+            },
+        },
     ];
-    const [selected, setSelected] = useState(0);
+
     const refs = useRef<(HTMLButtonElement | null)[]>([]);
 
     useEffect(() => {
-        refs.current[selected]?.focus();
-    }, [selected]);
-
-    useEffect(() => {
-        if (!isTop) return;
-        const onKeyDown = (e: KeyboardEvent) => {
-            if (e.code === 'ArrowUp') {
-                e.preventDefault();
-                setSelected((i) => (i - 1 + options.length) % options.length);
-            } else if (e.code === 'ArrowDown') {
-                e.preventDefault();
-                setSelected((i) => (i + 1) % options.length);
-            } else if (e.code === 'Enter') {
-                e.preventDefault();
-                options[selected].onSelect();
-            }
-        };
-        window.addEventListener('keydown', onKeyDown);
-        return () => {
-            window.removeEventListener('keydown', onKeyDown);
-        };
-    }, [options, selected, isTop]);
+        if (isTop) {
+            refs.current[0]?.focus();
+        }
+    }, [isTop]);
 
     return (
-        <Dialog title="Menu" onClose={() => closeDialog(dialogId)}>
+        <Dialog title="Menu" onClose={() => closeDialog(dialogId)} isTop={isTop}>
             <h3 className="text-red-600 font-mono text-lg mb-4">The Drift</h3>
             {options.map((opt, idx) => (
                 <MenuOption
                     key={opt.label}
                     label={opt.label}
                     onSelect={opt.onSelect}
-                    selected={idx === selected}
                     buttonRef={(el: HTMLButtonElement | null) => {
                         refs.current[idx] = el;
                     }}
+                    isTop={isTop}
                 />
             ))}
         </Dialog>

--- a/src/ui/PauseMenu.tsx
+++ b/src/ui/PauseMenu.tsx
@@ -5,19 +5,21 @@ import { useDialogManager } from './DialogManager';
 
 export interface PauseMenuProps {
     onExit: () => void;
+    dialogId: number;
+    isTop: boolean;
 }
 
-const PauseMenu: React.FC<PauseMenuProps> = ({ onExit }) => {
+const PauseMenu: React.FC<PauseMenuProps> = ({ onExit, dialogId, isTop }) => {
     const { showDialog, closeDialog } = useDialogManager();
     const options = [
         {
             label: 'Show Dialog',
             onSelect: () => {
-                showDialog(
-                    <Dialog title="Hello" onClose={closeDialog}>
+                showDialog((id) => (
+                    <Dialog title="Hello" onClose={() => closeDialog(id)}>
                         hello world
                     </Dialog>
-                );
+                ));
             },
         },
         { label: 'Exit', onSelect: () => { console.log('Exit selected'); onExit(); } },
@@ -30,6 +32,7 @@ const PauseMenu: React.FC<PauseMenuProps> = ({ onExit }) => {
     }, [selected]);
 
     useEffect(() => {
+        if (!isTop) return;
         const onKeyDown = (e: KeyboardEvent) => {
             if (e.code === 'ArrowUp') {
                 e.preventDefault();
@@ -46,26 +49,23 @@ const PauseMenu: React.FC<PauseMenuProps> = ({ onExit }) => {
         return () => {
             window.removeEventListener('keydown', onKeyDown);
         };
-    }, [options, selected]);
+    }, [options, selected, isTop]);
 
     return (
-        <div className="flex items-center justify-center w-full h-full bg-black bg-opacity-50">
-            <div className="w-64 bg-gray-800 bg-opacity-90 rounded p-4 text-center">
-                <h2 className="text-red-600 font-mono text-xl mb-2">Menu</h2>
-                <h3 className="text-red-600 font-mono text-lg mb-4">The Drift</h3>
-                {options.map((opt, idx) => (
-                    <MenuOption
-                        key={opt.label}
-                        label={opt.label}
-                        onSelect={opt.onSelect}
-                        selected={idx === selected}
-                        buttonRef={(el: HTMLButtonElement | null) => {
-                            refs.current[idx] = el;
-                        }}
-                    />
-                ))}
-            </div>
-        </div>
+        <Dialog title="Menu" onClose={() => closeDialog(dialogId)}>
+            <h3 className="text-red-600 font-mono text-lg mb-4">The Drift</h3>
+            {options.map((opt, idx) => (
+                <MenuOption
+                    key={opt.label}
+                    label={opt.label}
+                    onSelect={opt.onSelect}
+                    selected={idx === selected}
+                    buttonRef={(el: HTMLButtonElement | null) => {
+                        refs.current[idx] = el;
+                    }}
+                />
+            ))}
+        </Dialog>
     );
 };
 


### PR DESCRIPTION
## Summary
- add `DialogManager` context for stacking modal dialogs
- provide generic `Dialog` component
- connect pause menu with "Show Dialog" option
- wrap application in `DialogProvider` to disable pause toggle when a dialog is open
- document new components in `AGENTS.md`

## Testing
- `npm test`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_6850f4c9ddf8832e9cb645280c940436