### PR TITLE
Add BaseGame and refactor games

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -14,8 +14,8 @@
         {
             "type": "chrome",
             "request": "launch",
-            "name": "ThreeBodies",
-            "url": "http://localhost:5173/about",
+            "name": "BlackHole",
+            "url": "http://localhost:5173/blackhole",
             "webRoot": "${workspaceFolder}"
         }
     ]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,14 +87,21 @@ Maintains contact state between frames.
 
 ---
 
+### Common Game Utilities — `src/common/`
+
+#### `BaseGame.ts`
+
+Abstract base providing common initialization for canvas, viewport, world and
+integrator. Implements the main game loop with `start`, `pause`, `resume` and
+`resize` helpers. Games extend this class and override `update`/`frame` for
+custom logic.
+
 ### Game Layer — `src/game/`
 
 #### `Game.ts`
 
-Main game loop. Initializes objects, integrates physics, handles collisions, rendering and game state.
-**ENTRY POINT** for Codex understanding the system.
-Provides `resize(width, height)` to adjust canvas and viewport when the browser window size changes.
-Exposes `pause()`, `resume()` and `togglePause()` to control the simulation loop.
+Extends `BaseGame`. Sets up car, blocks and Terrorist, handles collisions and
+camera updates. Game state management lives here.
 
 #### `Block.ts`
 

--- a/src/common/BaseGame.ts
+++ b/src/common/BaseGame.ts
@@ -1,0 +1,87 @@
+import { Context } from '../engine/Context';
+import { FixedTimestepIntegrator } from '../engine/FixedTimestepIntegrator';
+import { Vec2D } from '../engine/vec/Vec2D';
+import { Viewport } from '../engine/Viewport';
+import { World } from '../engine/World';
+import { WorldRenderer } from '../engine/WorldRenderer';
+import { IGame } from '../ui/IGame';
+
+export abstract class BaseGame implements IGame {
+    protected context = new Context();
+    protected canvas: HTMLCanvasElement;
+    protected renderer: WorldRenderer;
+    protected viewport: Viewport;
+    protected world = new World(this.context);
+    protected integrator = new FixedTimestepIntegrator(60);
+    protected paused = false;
+
+    constructor(canvas: HTMLCanvasElement) {
+        this.canvas = canvas;
+        this.setupCanvasSize();
+        this.viewport = this.createViewport();
+        this.renderer = this.createRenderer();
+    }
+
+    protected setupCanvasSize() {
+        this.canvas.width = document.body.clientWidth;
+        this.canvas.height = document.body.clientHeight;
+    }
+
+    protected createViewport(): Viewport {
+        return new Viewport(
+            this.context,
+            Vec2D.set(new Vec2D(), 0, 0),
+            50,
+            Vec2D.set(new Vec2D(), this.canvas.width, this.canvas.height)
+        );
+    }
+
+    protected createRenderer(): WorldRenderer {
+        return new WorldRenderer(
+            this.context,
+            this.canvas.getContext('2d')!,
+            this.viewport
+        );
+    }
+
+    protected update(dt: number) {
+        this.world.update(dt);
+    }
+
+    protected frame() {
+        this.renderer.render(this.world);
+    }
+
+    public start() {
+        const loop = () => {
+            if (!this.paused) {
+                this.integrator.update((dt) => this.update(dt));
+            } else {
+                this.integrator.reset();
+            }
+
+            this.frame();
+            requestAnimationFrame(loop);
+        };
+
+        loop();
+    }
+
+    public resize(width: number, height: number) {
+        this.canvas.width = width;
+        this.canvas.height = height;
+        this.viewport.canvasSize.set(width, height);
+    }
+
+    public pause() {
+        this.paused = true;
+    }
+
+    public resume() {
+        this.paused = false;
+    }
+
+    public togglePause() {
+        this.paused = !this.paused;
+    }
+}

--- a/src/game/Car.ts
+++ b/src/game/Car.ts
@@ -23,7 +23,7 @@ export class Car extends Node {
         super();
         this.body = new RigidBody2D(initialPosition, initialRotation, 1, 0.1);
         
-        this.renderable = new CarRenderable(this.body.position);
+        this.renderable = new CarRenderable();
         
         this.controller = new VehicleController(this.body);
         this.controller.setFriction(0.3);

--- a/src/threebodies/Planet.ts
+++ b/src/threebodies/Planet.ts
@@ -1,0 +1,30 @@
+import { bindVec2 } from '../engine/bindVec2';
+import { Node } from '../engine/Node';
+import { RigidBody2D } from '../engine/physics/RigidBody2D';
+import { Vec2D } from '../engine/vec/Vec2D';
+import { PlanetRenderable } from './PlanetRenderable';
+
+export class Planet extends Node {
+    body: RigidBody2D;
+    renderable: PlanetRenderable;
+    constructor(
+        public readonly options: {
+            color: string;
+            radius: number;
+            mass: number;
+        }
+    ) {
+        super();
+        this.body = new RigidBody2D(new Vec2D(), 0, options.mass, 0);
+        this.renderable = new PlanetRenderable(
+            this.options.color,
+            options.mass,
+            options.radius
+        );
+
+        this.add(this.renderable);
+        this.add(this.body);
+
+        bindVec2(this.renderable, 'position').from(this.body, 'position');
+    }
+}

--- a/src/threebodies/PlanetRenderable.ts
+++ b/src/threebodies/PlanetRenderable.ts
@@ -1,0 +1,27 @@
+import { Node } from '../engine/Node';
+import { Vec2D } from '../engine/vec/Vec2D';
+import { Viewport } from '../engine/Viewport';
+
+export class PlanetRenderable extends Node {
+    constructor(
+        public readonly color: string = 'red',
+        public readonly mass = 1,
+        public readonly radius = 1
+    ) {
+        super();
+    }
+
+    public readonly position = new Vec2D();
+
+    render(ctx: CanvasRenderingContext2D, viewport: Viewport) {
+        ctx.save();
+
+        ctx.translate(this.position.x, this.position.y);
+        ctx.beginPath();
+        ctx.arc(0, 0, this.radius, 0, 2 * Math.PI);
+        ctx.fillStyle = this.color;
+        ctx.fill();
+
+        ctx.restore();
+    }
+}

--- a/src/threebodies/ThreeBodiesGameApp.tsx
+++ b/src/threebodies/ThreeBodiesGameApp.tsx
@@ -5,7 +5,6 @@ export const ThreeBodiesGameApp: React.FC = () => {
     return (
         <GameCanvas
             gameFactory={(canvas) => new ThreeBodiesGame(canvas)}
-            key="game"
             paused={false}
         />
     );

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -1,13 +1,13 @@
 import React from 'react';
 import { BrowserRouter, Routes, Route } from 'react-router-dom';
 import GameApp from './GameApp';
-import AboutPage from './AboutPage';
+import BlackholePage from './BlackholePage';
 
 const App: React.FC = () => (
     <BrowserRouter>
         <Routes>
             <Route path="/" element={<GameApp />} />
-            <Route path="/about" element={<AboutPage />} />
+            <Route path="/blackhole" element={<BlackholePage />} />
         </Routes>
     </BrowserRouter>
 );

--- a/src/ui/BlackholePage.tsx
+++ b/src/ui/BlackholePage.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { ThreeBodiesGameApp } from '../threebodies/ThreeBodiesGameApp';
 
-const AboutPage: React.FC = () => (
+const BlackholePage: React.FC = () => (
     <div className="flex items-center justify-center h-screen">
         <div>
             <ThreeBodiesGameApp />
@@ -9,4 +9,4 @@ const AboutPage: React.FC = () => (
     </div>
 );
 
-export default AboutPage;
+export default BlackholePage;


### PR DESCRIPTION
## Summary
- create `BaseGame` class with common game loop helpers
- refactor `Game` and `ThreeBodiesGame` to extend `BaseGame`
- adjust `CarRenderable` usage
- document `BaseGame` in AGENTS guide

## Testing
- `npm run typecheck`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685506f0092c832ea3c99bbe4ee06a19